### PR TITLE
Replace embedding version with md5

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -13,7 +13,6 @@ class Item < ActiveRecord::Base
   default_scope { where(deleted: false) }
 
   SORT_ORDER = %w(artist title year label format).freeze
-  EMBEDDING_VERSION = 2.freeze
 
   def self.search(query = "")
     query = query.to_s

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -6,7 +6,7 @@
         - item.errors.full_messages.each do |msg|
           %li= msg
 
-  - (Item.column_names - %w[id created_at updated_at deleted genres styles embedding]).each do |field|
+  - (Item.column_names - %w[id created_at updated_at deleted genres styles embedding embedding_md5]).each do |field|
     .form-group
       = f.label field
       = f.text_field field, class: "form-control"

--- a/db/migrate/20231112230420_add_embedding_md5_to_items.rb
+++ b/db/migrate/20231112230420_add_embedding_md5_to_items.rb
@@ -1,0 +1,5 @@
+class AddEmbeddingMd5ToItems < ActiveRecord::Migration[7.1]
+  def change
+    add_column :items, :embedding_md5, :string
+  end
+end

--- a/db/migrate/20231112230437_drop_items_embedding_version.rb
+++ b/db/migrate/20231112230437_drop_items_embedding_version.rb
@@ -1,0 +1,5 @@
+class DropItemsEmbeddingVersion < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :items, :embedding_version
+  end
+end

--- a/db/migrate/20231112230659_backfill_embedding_md5.rb
+++ b/db/migrate/20231112230659_backfill_embedding_md5.rb
@@ -1,0 +1,16 @@
+class BackfillEmbeddingMd5 < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    Item.where(embedding_md5: nil).where.not(embedding: nil).find_each do |item|
+      item.embedding_md5 = md5(item.as_embedding)
+      item.save!
+    end
+  end
+
+  private
+
+  def md5(text)
+    Digest::MD5.hexdigest(text)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_04_192504) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_12_230659) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "vector"
@@ -77,7 +77,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_04_192504) do
     t.text "genres", default: [], array: true
     t.text "styles", default: [], array: true
     t.vector "embedding", limit: 1536
-    t.integer "embedding_version"
+    t.string "embedding_md5"
     t.index "to_tsvector('english'::regconfig, artist)", name: "items_to_tsvector_idx1", using: :gin
     t.index "to_tsvector('english'::regconfig, color)", name: "items_to_tsvector_idx5", using: :gin
     t.index "to_tsvector('english'::regconfig, condition)", name: "items_to_tsvector_idx4", using: :gin
@@ -90,7 +90,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_04_192504) do
     t.index ["condition"], name: "index_items_on_condition"
     t.index ["created_at"], name: "index_items_on_created_at"
     t.index ["embedding"], name: "index_items_on_embedding", opclass: :vector_cosine_ops, using: :hnsw
-    t.index ["embedding_version"], name: "index_items_on_embedding_version"
     t.index ["format"], name: "index_items_on_format"
     t.index ["label"], name: "index_items_on_label"
     t.index ["price_paid"], name: "index_items_on_price_paid"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ volumes:
   postgres:
 services:
   db:
-    image: gordondiggs/pgvector:14
+    image: ankane/pgvector:v0.5.1 #pg 15
     volumes:
       - postgres:/var/lib/postgresql/data
     ports:


### PR DESCRIPTION
This will make sure that any code changes to the embedding structure will trigger re-calculation of embeddings. Also adds a backfill job